### PR TITLE
Fix setup.py for pip 10 and above

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 
 import os
 import sys
-from pip.req import parse_requirements
 from codecs import open
 
 try:
@@ -18,8 +17,8 @@ packages = [
     'python_kafka_logging',
 ]
 
-install_requirements = parse_requirements('requirements.txt', session=False)
-requirements = [str(ir.req) for ir in install_requirements]
+with open("requirements.txt", "r") as fs:
+    requirements = [r for r in fs.read().splitlines() if (len(r) > 0 and not r.startswith("#"))]
 
 with open('README.rst', 'r', 'utf-8') as f:
     readme = f.read()


### PR DESCRIPTION
The current setup.py file doesn't work for pip version 10 and above. This is because the people who released pip 10 intentionally broke the internal API.

```
(scratch) ~/src/forks/python-kafka-logging (master ✔) ᐅ pip install -e .
Obtaining file:///Users/patrick/src/forks/python-kafka-logging
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/Users/patrick/src/forks/python-kafka-logging/setup.py", line 5, in <module>
        from pip.req import parse_requirements
    ModuleNotFoundError: No module named 'pip.req'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /Users/patrick/src/forks/python-kafka-logging/
You are using pip version 10.0.1, however version 19.0.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
(scratch) ~/src/forks/python-kafka-logging (master ✔) ᐅ
```

